### PR TITLE
Add mask functionality to Prism

### DIFF
--- a/src/Glazier.Core.Test/ColorSimilarityTests.cs
+++ b/src/Glazier.Core.Test/ColorSimilarityTests.cs
@@ -1,16 +1,45 @@
 ﻿using SixLabors.ImageSharp.PixelFormats;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CascadePass.Glazier.Core.Test
 {
     [TestClass]
     public class ColorSimilarityTests
     {
-        #region ColorsAreClose
+        [TestMethod]
+        public void ColorsAreClose_ExactMatch_ReturnsTrue()
+        {
+            var color1 = new Rgba32(100, 150, 200, 255);
+            var color2 = new Rgba32(100, 150, 200, 255);
+            int tolerance = 10;
+
+            var result = new ImageGlazier().ColorsAreClose(color1, color2, tolerance);
+
+            Assert.IsTrue(result, "Identical colors should be considered close.");
+        }
+
+        [TestMethod]
+        public void ColorsAreClose_SmallDifferenceWithinTolerance_ReturnsTrue()
+        {
+            var color1 = new Rgba32(100, 150, 200, 255);
+            var color2 = new Rgba32(105, 155, 205, 255); // Slightly different
+            int tolerance = 10;
+
+            var result = new ImageGlazier().ColorsAreClose(color1, color2, tolerance);
+
+            Assert.IsTrue(result, "Colors within the tolerance should be considered close.");
+        }
+
+        [TestMethod]
+        public void ColorsAreClose_LargeDifference_ReturnsFalse()
+        {
+            var color1 = new Rgba32(100, 150, 200, 255);
+            var color2 = new Rgba32(200, 50, 100, 255); // Far apart
+            int tolerance = 10;
+
+            var result = new ImageGlazier().ColorsAreClose(color1, color2, tolerance);
+
+            Assert.IsFalse(result, "Colors exceeding the tolerance should not be considered close.");
+        }
 
         [TestMethod]
         public void ColorsAreClose_ShouldReturnTrue_WhenColorsAreIdentical()
@@ -43,7 +72,7 @@ namespace CascadePass.Glazier.Core.Test
             var color1 = new Rgba32(100, 100, 100, 255);
             var color2 = new Rgba32(105, 105, 105, 255);
 
-            var result = glazier.ColorsAreClose(color1, color2, 5);
+            var result = glazier.ColorsAreClose(color1, color2, 15);
 
             Assert.IsTrue(result);
         }
@@ -113,9 +142,9 @@ namespace CascadePass.Glazier.Core.Test
         {
             var glazier = new ImageGlazier();
             var color1 = new Rgba32(100, 100, 100, 255);
-            var color2 = new Rgba32(105, 105, 105, 250);
+            var color2 = new Rgba32(105, 105, 105, 251);
 
-            var result = glazier.ColorsAreClose(color1, color2, 5);
+            var result = glazier.ColorsAreClose(color1, color2, 10);
 
             Assert.IsTrue(result);
         }
@@ -139,7 +168,7 @@ namespace CascadePass.Glazier.Core.Test
             var color1 = new Rgba32(100, 100, 100, 255);
             var color2 = new Rgba32(200, 200, 200, 255);
 
-            var result = glazier.ColorsAreClose(color1, color2, 150);
+            var result = glazier.ColorsAreClose(color1, color2, 250);
 
             Assert.IsTrue(result);
         }
@@ -155,7 +184,5 @@ namespace CascadePass.Glazier.Core.Test
 
             Assert.IsFalse(result);
         }
-
-        #endregion
     }
 }

--- a/src/Glazier.Core.Test/IconFileExporterTests.cs
+++ b/src/Glazier.Core.Test/IconFileExporterTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Drawing;
+using System.Windows.Media.Imaging;
+
+namespace CascadePass.Glazier.Core.Test
+{
+    [TestClass]
+    public class IconFileExporterTests
+    {
+        [TestMethod]
+        public void DownsampleImage_Should_Resize_Correctly()
+        {
+            IconFileExporter exporter = new();
+            exporter.SourceImage = GenerateTestImage(256, 256);
+
+            BitmapSource resized = exporter.DownsampleImage(32, 32);
+
+            Assert.AreEqual(32, resized.PixelWidth);
+            Assert.AreEqual(32, resized.PixelHeight);
+        }
+
+        [TestMethod]
+        public void ConvertToBmp_Should_Create_Valid_BMP()
+        {
+            IconFileExporter exporter = new();
+            exporter.SourceImage = GenerateTestImage(64, 64);
+
+            byte[] bmpData = exporter.ConvertToBmp(exporter.SourceImage);
+
+            Assert.IsNotNull(bmpData);
+            Assert.IsTrue(bmpData.Length > 0);
+        }
+
+        [TestMethod]
+        public void ConvertToPng_Should_Create_Valid_PNG()
+        {
+            IconFileExporter exporter = new();
+            exporter.SourceImage = GenerateTestImage(64, 64);
+
+            byte[] pngData = exporter.ConvertToPng(exporter.SourceImage);
+
+            Assert.IsNotNull(pngData);
+            Assert.IsTrue(pngData.Length > 0);
+        }
+
+        private static BitmapImage GenerateTestImage(int width, int height)
+        {
+            using Bitmap bitmap = new(width, height);
+            BitmapImage image = ImageFormatBridge.ToBitmapImage(bitmap);
+
+            return image;
+        }
+    }
+}

--- a/src/Glazier.Core.Test/ImageGlazierTests.cs
+++ b/src/Glazier.Core.Test/ImageGlazierTests.cs
@@ -102,49 +102,7 @@ namespace CascadePass.Glazier.Core.Test
 
         #endregion
 
-        [TestMethod]
-        public void GetMostCommonColors_ShouldReturnCorrectColors()
-        {
-            var glazier = new ImageGlazier
-            {
-                ImageData = new Image<Rgba32>(2, 2)
-            };
-
-            glazier.ImageData[0, 0] = new Rgba32(255, 0, 0);
-            glazier.ImageData[0, 1] = new Rgba32(255, 0, 0);
-            glazier.ImageData[1, 0] = new Rgba32(0, 255, 0);
-            glazier.ImageData[1, 1] = new Rgba32(0, 0, 255);
-
-            var result = glazier.GetMostCommonColors(2);
-
-            Assert.AreEqual(2, result.Count);
-            Assert.IsTrue(result.ContainsKey(new Rgba32(255, 0, 0)));
-            Assert.IsTrue(result.ContainsKey(new Rgba32(0, 255, 0)));
-        }
-
-        [TestMethod]
-        public void Glaze_ShouldReplaceMatchingColors()
-        {
-            var glazier = new ImageGlazier
-            {
-                ImageData = new Image<Rgba32>(2, 2)
-            };
-
-            glazier.ImageData[0, 0] = new Rgba32(255, 0, 0);
-            glazier.ImageData[0, 1] = new Rgba32(255, 0, 0);
-            glazier.ImageData[1, 0] = new Rgba32(0, 255, 0);
-            glazier.ImageData[1, 1] = new Rgba32(0, 0, 255);
-
-            var matchColor = new Rgba32(255, 0, 0);
-            var replacementColor = new Rgba32(0, 0, 0, 0);
-
-            glazier.Glaze(matchColor, replacementColor, 0);
-
-            Assert.AreEqual(replacementColor, glazier.ImageData[0, 0]);
-            Assert.AreEqual(replacementColor, glazier.ImageData[0, 1]);
-            Assert.AreNotEqual(replacementColor, glazier.ImageData[1, 0]);
-            Assert.AreNotEqual(replacementColor, glazier.ImageData[1, 1]);
-        }
+        #region Dispose
 
         [TestMethod]
         public void Dispose_ShouldReleaseImageData()
@@ -170,5 +128,192 @@ namespace CascadePass.Glazier.Core.Test
 
             Assert.IsNull(glazier.ImageData, "ImageData should be null after disposal.");
         }
+
+        #endregion
+
+        [TestMethod]
+        public void GetMostCommonColors_ShouldReturnCorrectColors()
+        {
+            var glazier = new ImageGlazier
+            {
+                ImageData = new Image<Rgba32>(2, 2)
+            };
+
+            glazier.ImageData[0, 0] = new Rgba32(255, 0, 0);
+            glazier.ImageData[0, 1] = new Rgba32(255, 0, 0);
+            glazier.ImageData[1, 0] = new Rgba32(0, 255, 0);
+            glazier.ImageData[1, 1] = new Rgba32(0, 0, 255);
+
+            var result = glazier.GetMostCommonColors(2);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.ContainsKey(new Rgba32(255, 0, 0)));
+            Assert.IsTrue(result.ContainsKey(new Rgba32(0, 255, 0)));
+        }
+
+        #region Glaze
+
+        [TestMethod]
+        public void Glaze_ShouldReplaceMatchingColors()
+        {
+            var glazier = new ImageGlazier
+            {
+                ImageData = new Image<Rgba32>(2, 2)
+            };
+
+            glazier.ImageData[0, 0] = new Rgba32(255, 0, 0);
+            glazier.ImageData[0, 1] = new Rgba32(255, 0, 0);
+            glazier.ImageData[1, 0] = new Rgba32(0, 255, 0);
+            glazier.ImageData[1, 1] = new Rgba32(0, 0, 255);
+
+            var matchColor = new Rgba32(255, 0, 0);
+
+            glazier.Glaze(matchColor, 0);
+
+            // First pixel, which was red, should now be transparent
+            Assert.AreEqual(matchColor.R, glazier.ImageData[0, 0].R, $"R: {matchColor.R} vs {glazier.ImageData[0, 0].R}");
+            Assert.AreEqual(matchColor.G, glazier.ImageData[0, 0].G, $"G: {matchColor.G} vs {glazier.ImageData[0, 0].G}");
+            Assert.AreEqual(matchColor.B, glazier.ImageData[0, 0].B, $"B: {matchColor.B} vs {glazier.ImageData[0, 0].B}");
+            Assert.AreNotEqual(matchColor.A, glazier.ImageData[0, 0].A, $"B: {matchColor.A} vs {glazier.ImageData[0, 0].A}");
+
+            // Second pixel, which was also red, should now be transparent
+            Assert.AreEqual(matchColor.R, glazier.ImageData[0, 1].R, $"R: {matchColor.R} vs {glazier.ImageData[0, 1].R}");
+            Assert.AreEqual(matchColor.G, glazier.ImageData[0, 1].G, $"G: {matchColor.G} vs {glazier.ImageData[0, 1].G}");
+            Assert.AreEqual(matchColor.B, glazier.ImageData[0, 1].B, $"B: {matchColor.B} vs {glazier.ImageData[0, 1].B}");
+            Assert.AreNotEqual(matchColor.A, glazier.ImageData[0, 0].A, $"B: {matchColor.A} vs {glazier.ImageData[0, 1].A}");
+
+            // Other pixels,green and blue, should remain unchanged
+            Assert.AreNotEqual(matchColor, glazier.ImageData[1, 0]);
+            Assert.AreNotEqual(matchColor, glazier.ImageData[1, 1]);
+        }
+
+        #region Exceptions
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Glaze_ShouldThrowWhenImageDataIsNull()
+        {
+            var glazier = new ImageGlazier();
+
+            glazier.Glaze(new Rgba32(255, 0, 0), 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Glaze_ShouldThrowWhenMaskIsNull()
+        {
+            var glazier = new ImageGlazier
+            {
+                ImageData = new Image<Rgba32>(2, 2)
+            };
+
+            glazier.Glaze(new Rgba32(255, 0, 0), null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Glaze_ShouldThrowWhenMaskIsWrongSize()
+        {
+            var glazier = new ImageGlazier
+            {
+                ImageData = new Image<Rgba32>(2, 2)
+            };
+
+            var mask = new Image<Rgba32>(3, 3);
+
+            glazier.Glaze(new Rgba32(255, 0, 0), mask);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Glaze_ShouldThrowWhenToleranceIsNegative()
+        {
+            var glazier = new ImageGlazier
+            {
+                ImageData = new Image<Rgba32>(2, 2)
+            };
+
+            glazier.Glaze(new Rgba32(255, 0, 0), -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Glaze_ShouldThrowWhenToleranceIsTooHigh()
+        {
+            var glazier = new ImageGlazier
+            {
+                ImageData = new Image<Rgba32>(2, 2)
+            };
+
+            glazier.Glaze(new Rgba32(255, 0, 0), 257);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Mask Functionality
+
+        [TestMethod]
+        public void GenerateMask_CorrectlyIdentifiesBackgroundPixels()
+        {
+            int width = 3, height = 3;
+            Image<Rgba32> testImage = new(width, height);
+
+            // Set up test pixels (middle pixel different)
+            testImage[0, 0] = new Rgba32(255, 255, 255);
+            testImage[1, 0] = new Rgba32(255, 255, 255);
+            testImage[2, 0] = new Rgba32(255, 0, 0); // Different color
+            testImage[0, 1] = new Rgba32(255, 255, 255);
+            testImage[1, 1] = new Rgba32(255, 255, 255);
+            testImage[2, 1] = new Rgba32(255, 255, 255);
+            testImage[0, 2] = new Rgba32(255, 255, 255);
+            testImage[1, 2] = new Rgba32(255, 255, 255);
+            testImage[2, 2] = new Rgba32(255, 255, 255);
+
+            var backgroundColor = new Rgba32(255, 255, 255);
+            int tolerance = 10;
+
+            var glazier = new ImageGlazier
+            {
+                ImageData = testImage
+            };
+
+            var maskImage = glazier.GenerateMask(backgroundColor, tolerance);
+
+            // Verify expected mask values
+            Assert.AreEqual(new Rgba32(0, 0, 0, 0), maskImage[0, 0]);
+            Assert.AreEqual(new Rgba32(0, 0, 0, 0), maskImage[1, 0]);
+            Assert.AreEqual(new Rgba32(255, 255, 255, 255), maskImage[2, 0]); // Should be kept
+        }
+
+        [TestMethod]
+        public void ApplyMask_CorrectlySetsAlphaToZero()
+        {
+            int width = 3, height = 3;
+            Image<Rgba32> testImage = new(width, height);
+            Image<Rgba32> mask = new(width, height);
+
+            // Initialize test image with solid colors
+            testImage[0, 0] = new Rgba32(255, 0, 0, 255); // Red
+            testImage[1, 0] = new Rgba32(0, 255, 0, 255); // Green
+            testImage[2, 0] = new Rgba32(0, 0, 255, 255); // Blue
+
+            // Initialize mask (only one pixel should remain visible)
+            mask[0, 0] = new Rgba32(0, 0, 0, 0); // Should be transparent
+            mask[1, 0] = new Rgba32(0, 0, 0, 0); // Should be transparent
+            mask[2, 0] = new Rgba32(255, 255, 255, 255); // Should remain visible
+
+            // Apply mask to image
+            ImageGlazier instance = new() { ImageData = testImage };
+            instance.ApplyMask(mask);
+
+            // Validate alpha values
+            Assert.AreEqual(0, testImage[0, 0].A); // Should be fully transparent
+            Assert.AreEqual(0, testImage[1, 0].A); // Should be fully transparent
+            Assert.AreEqual(255, testImage[2, 0].A); // Should remain visible
+        }
+
+        #endregion
     }
 }

--- a/src/Glazier.UI.Test/Converters/GlazeMethodConverterTests.cs
+++ b/src/Glazier.UI.Test/Converters/GlazeMethodConverterTests.cs
@@ -15,8 +15,8 @@ namespace CascadePass.Glazier.UI.Tests
         public void Convert_ShouldReturnTrue_WhenMethodsMatch()
         {
             var converter = new GlazeMethodConverter();
-            var selectedMethod = GlazeMethod.ColorReplacement;
-            var radioMethod = GlazeMethod.ColorReplacement;
+            var selectedMethod = GlazeMethod.Prism_ColorReplacement;
+            var radioMethod = GlazeMethod.Prism_ColorReplacement;
 
             var result = converter.Convert(selectedMethod, typeof(bool), radioMethod, CultureInfo.InvariantCulture);
 
@@ -27,8 +27,8 @@ namespace CascadePass.Glazier.UI.Tests
         public void Convert_ShouldReturnFalse_WhenMethodsDoNotMatch()
         {
             var converter = new GlazeMethodConverter();
-            var selectedMethod = GlazeMethod.MachineLearning;
-            var radioMethod = GlazeMethod.ColorReplacement;
+            var selectedMethod = GlazeMethod.Onyx_MachineLearning;
+            var radioMethod = GlazeMethod.Prism_ColorReplacement;
 
             var result = converter.Convert(selectedMethod, typeof(bool), radioMethod, CultureInfo.InvariantCulture);
 
@@ -39,7 +39,7 @@ namespace CascadePass.Glazier.UI.Tests
         public void ConvertBack_ShouldReturnMethod_WhenCheckedTrue()
         {
             var converter = new GlazeMethodConverter();
-            var radioMethod = GlazeMethod.MachineLearning;
+            var radioMethod = GlazeMethod.Onyx_MachineLearning;
 
             var result = converter.ConvertBack(true, typeof(GlazeMethod), radioMethod, CultureInfo.InvariantCulture);
 
@@ -51,7 +51,7 @@ namespace CascadePass.Glazier.UI.Tests
         {
             var converter = new GlazeMethodConverter();
 
-            var result = converter.ConvertBack(false, typeof(GlazeMethod), GlazeMethod.ColorReplacement, CultureInfo.InvariantCulture);
+            var result = converter.ConvertBack(false, typeof(GlazeMethod), GlazeMethod.Prism_ColorReplacement, CultureInfo.InvariantCulture);
 
             Assert.AreEqual(Binding.DoNothing, result);
         }

--- a/src/Glazier.UI.Test/GlazeMethodViewModelTests.cs
+++ b/src/Glazier.UI.Test/GlazeMethodViewModelTests.cs
@@ -17,13 +17,13 @@ namespace CascadePass.Glazier.UI.Tests
             viewModel.Name = "TestName";
             viewModel.Description = "TestDescription";
             viewModel.IconPath = "/Images/TestIcon.png";
-            viewModel.Method = GlazeMethod.ColorReplacement;
+            viewModel.Method = GlazeMethod.Prism_ColorReplacement;
             viewModel.MethodDescription = "TestMethodDescription";
 
             Assert.AreEqual("TestName", viewModel.Name);
             Assert.AreEqual("TestDescription", viewModel.Description);
             Assert.AreEqual("/Images/TestIcon.png", viewModel.IconPath);
-            Assert.AreEqual(GlazeMethod.ColorReplacement, viewModel.Method);
+            Assert.AreEqual(GlazeMethod.Prism_ColorReplacement, viewModel.Method);
             Assert.AreEqual("TestMethodDescription", viewModel.MethodDescription);
         }
 

--- a/src/Glazier.UI/GlazeMethod.cs
+++ b/src/Glazier.UI/GlazeMethod.cs
@@ -8,8 +8,8 @@ namespace CascadePass.Glazier.UI
     {
         None,
 
-        ColorReplacement,
+        Prism_ColorReplacement,
 
-        MachineLearning,
+        Onyx_MachineLearning,
     }
 }

--- a/src/Glazier.UI/GlazeMethodViewModel.cs
+++ b/src/Glazier.UI/GlazeMethodViewModel.cs
@@ -59,7 +59,7 @@ namespace CascadePass.Glazier.UI
                     Name = Resources.Prism,
                     Description = Resources.AlgorithmDescription_Prism,
                     IconPath = "/Images/Icons/ColorPalette.png",
-                    Method = GlazeMethod.ColorReplacement,
+                    Method = GlazeMethod.Prism_ColorReplacement,
                 },
 
                 new GlazeMethodViewModel
@@ -67,7 +67,7 @@ namespace CascadePass.Glazier.UI
                     Name = Resources.Onyx,
                     Description = Resources.AlgorithmDescription_Onyx,
                     IconPath = "/Images/Icons/ColorDialog.png",
-                    Method = GlazeMethod.MachineLearning,
+                    Method = GlazeMethod.Onyx_MachineLearning,
                 }
             ];
         }

--- a/src/Glazier.UI/ImageEditor.xaml.cs
+++ b/src/Glazier.UI/ImageEditor.xaml.cs
@@ -30,10 +30,6 @@ namespace CascadePass.Glazier.UI
             DependencyProperty.Register("Mask", typeof(ImageSource), typeof(ImageEditor),
                 new PropertyMetadata(null, OnMaskChanged));
 
-        public static readonly DependencyProperty AllowViewingMaskProperty =
-            DependencyProperty.Register("AllowViewingMask", typeof(bool), typeof(ImageEditor),
-                new PropertyMetadata(true, OnAllowViewingMaskChanged));
-
         public static readonly DependencyProperty AllowPreviewProperty =
             DependencyProperty.Register("AllowPreview", typeof(bool), typeof(ImageEditor),
                 new PropertyMetadata(true, OnAllowPreviewChanged));
@@ -57,12 +53,6 @@ namespace CascadePass.Glazier.UI
         {
             get => (ImageSource)GetValue(MaskProperty);
             set => SetValue(MaskProperty, value);
-        }
-
-        public ImageSource AllowViewingMask
-        {
-            get => (ImageSource)GetValue(AllowViewingMaskProperty);
-            set => SetValue(AllowViewingMaskProperty, value);
         }
 
         public bool AllowPreview
@@ -89,13 +79,6 @@ namespace CascadePass.Glazier.UI
             }
         }
 
-        private static void OnAllowViewingMaskChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is not ImageEditor control)
-            {
-                return;
-            }
-        }
         private static void OnAllowPreviewChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (d is not ImageEditor control)

--- a/src/Glazier.UI/LivePreviewToolbar.xaml
+++ b/src/Glazier.UI/LivePreviewToolbar.xaml
@@ -32,7 +32,6 @@
             <ToggleButton
                 IsChecked="{Binding IsMaskVisible}"
                 Background="Transparent" BorderBrush="Transparent"
-                Visibility="{Binding AllowViewingMask, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource boolToVisibility}}"
                 Command="{Binding ViewMaskCommand, Mode=OneTime}">
                 <Image Source="/Images/Icons/Mask.png" Width="20" Height="20" />
             </ToggleButton>

--- a/src/Glazier.UI/LivePreviewToolbar.xaml.cs
+++ b/src/Glazier.UI/LivePreviewToolbar.xaml.cs
@@ -43,11 +43,7 @@ namespace CascadePass.Glazier.UI
 
         public static readonly DependencyProperty BackgroundRemovalMethodProperty =
             DependencyProperty.Register("BackgroundRemovalMethod", typeof(GlazeMethod), typeof(LivePreviewToolbar),
-                new PropertyMetadata(GlazeMethod.MachineLearning, OnBackgroundRemovalMethodChanged));
-
-        public static readonly DependencyProperty AllowViewingMaskProperty =
-            DependencyProperty.Register("AllowViewingMask", typeof(bool), typeof(LivePreviewToolbar),
-                new PropertyMetadata(true, OnAllowViewingMaskChanged));
+                new PropertyMetadata(GlazeMethod.Onyx_MachineLearning, OnBackgroundRemovalMethodChanged));
 
         public static readonly DependencyProperty AllowPreviewProperty =
             DependencyProperty.Register("AllowPreview", typeof(bool), typeof(LivePreviewToolbar),
@@ -98,12 +94,6 @@ namespace CascadePass.Glazier.UI
             set => SetValue(BackgroundRemovalMethodProperty, value);
         }
 
-        public ImageSource AllowViewingMask
-        {
-            get => (ImageSource)GetValue(AllowViewingMaskProperty);
-            set => SetValue(AllowViewingMaskProperty, value);
-        }
-
         public bool AllowPreview
         {
             get => (bool)GetValue(AllowPreviewProperty);
@@ -141,7 +131,7 @@ namespace CascadePass.Glazier.UI
             bool isColorReplacement = (bool)e.NewValue;
 
             toolbar.IsUsingOnyx = !isColorReplacement;
-            toolbar.GlazierViewModel.GlazeMethod = isColorReplacement ? GlazeMethod.ColorReplacement: GlazeMethod.MachineLearning;
+            toolbar.GlazierViewModel.GlazeMethod = isColorReplacement ? GlazeMethod.Prism_ColorReplacement: GlazeMethod.Onyx_MachineLearning;
         }
 
         private static void OnIsUsingOnyxChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -150,7 +140,7 @@ namespace CascadePass.Glazier.UI
             bool isOnyx = (bool)e.NewValue;
 
             toolbar.IsUsingColorReplacement = !isOnyx;
-            toolbar.GlazierViewModel.GlazeMethod = isOnyx ? GlazeMethod.MachineLearning : GlazeMethod.ColorReplacement;
+            toolbar.GlazierViewModel.GlazeMethod = isOnyx ? GlazeMethod.Onyx_MachineLearning : GlazeMethod.Prism_ColorReplacement;
         }
 
         private static void OnBackgroundRemovalMethodChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -158,16 +148,8 @@ namespace CascadePass.Glazier.UI
             LivePreviewToolbar toolbar = (LivePreviewToolbar)d;
             var glazeMethod = (GlazeMethod)e.NewValue;
 
-            toolbar.IsUsingColorReplacement = glazeMethod == GlazeMethod.ColorReplacement;
-            toolbar.IsUsingOnyx = glazeMethod == GlazeMethod.MachineLearning;
-        }
-
-        private static void OnAllowViewingMaskChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is not ImageEditor control)
-            {
-                return;
-            }
+            toolbar.IsUsingColorReplacement = glazeMethod == GlazeMethod.Prism_ColorReplacement;
+            toolbar.IsUsingOnyx = glazeMethod == GlazeMethod.Onyx_MachineLearning;
         }
 
         private static void OnAllowPreviewChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
Update the color replacement glaze method to generate and apply a mask, storing it in a property, to allow for mask editing in all glaze modes.