### PR TITLE
Fix bug: could not set Prism mode w/o image

### DIFF
--- a/src/Glazier.Core.Test/OnyxBackgroundRemoverTests.cs
+++ b/src/Glazier.Core.Test/OnyxBackgroundRemoverTests.cs
@@ -275,23 +275,6 @@ namespace CascadePass.Glazier.Core.Test
             Assert.IsTrue(darkAdjustment >= 0.0f);
         }
 
-        [TestMethod]
-        public void AdjustBrightnessSensitivity_ShouldRunEfficiently()
-        {
-            using Bitmap largeImage = new(2000, 2000);
-            using Graphics g = Graphics.FromImage(largeImage);
-            g.Clear(Color.Gray);
-
-            OnyxBackgroundRemover processor = new();
-            Stopwatch timer = new();
-
-            timer.Start();
-            float adjustedBrightness = processor.AdjustBrightnessSensitivity(largeImage);
-            timer.Stop();
-
-            Assert.IsTrue(timer.ElapsedMilliseconds < 500);
-        }
-
         #endregion
 
         #region EnhanceColorSaturation

--- a/src/Glazier.UI/App.xaml
+++ b/src/Glazier.UI/App.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary>
             <BooleanToVisibilityConverter x:Key="boolToVisibility" />
             <local:ColorToBrushConverter x:Key="colorToBrush" />
+            <local:GlazeMethodToBoolConverter x:Key="glazeMethodToBool" />
 
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Themes/Dark.xaml" />

--- a/src/Glazier.UI/GlazierViewModel.cs
+++ b/src/Glazier.UI/GlazierViewModel.cs
@@ -575,7 +575,7 @@ namespace CascadePass.Glazier.UI
 
             ImageEditor imageEditor = new()
             {
-                Image = this.PreviewImage,
+                GlazierViewModel = this,
                 Background = backgroundBrush,
                 AllowPreview = false,
             };

--- a/src/Glazier.UI/ImageEditor.xaml
+++ b/src/Glazier.UI/ImageEditor.xaml
@@ -15,7 +15,7 @@
 
             <Image
                 x:Name="PreviewImage"
-                Source="{Binding Image, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                Source="{Binding GlazierViewModel.PreviewImage, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
                 Stretch="Uniform"
                 VerticalAlignment="Center"
                 Width="{Binding ActualWidth, ElementName=InkCanvasContainer}"
@@ -23,7 +23,8 @@
         </InkCanvas>
 
         <local:LivePreviewToolbar
-            BackgroundRemovalMethod="{Binding GlazeMethod}"
+            GlazierViewModel="{Binding GlazierViewModel}"
+            BackgroundRemovalMethod="{Binding GlazierViewModel.GlazeMethod}"
             AllowPreview="{Binding AllowPreview, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
             />
     </Grid>

--- a/src/Glazier.UI/ImageEditor.xaml.cs
+++ b/src/Glazier.UI/ImageEditor.xaml.cs
@@ -1,17 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace CascadePass.Glazier.UI
 {
@@ -22,13 +12,17 @@ namespace CascadePass.Glazier.UI
     {
         #region Dependency Properties
 
-        public static readonly DependencyProperty ImageProperty =
-            DependencyProperty.Register("Image", typeof(ImageSource), typeof(ImageEditor),
-                new PropertyMetadata(null, OnImageChanged));
+        public static readonly DependencyProperty GlazierViewModelProperty =
+            DependencyProperty.Register("GlazierViewModel", typeof(GlazierViewModel), typeof(ImageEditor),
+                new PropertyMetadata(null, OnGlazierViewModelChanged));
 
-        public static readonly DependencyProperty MaskProperty =
-            DependencyProperty.Register("Mask", typeof(ImageSource), typeof(ImageEditor),
-                new PropertyMetadata(null, OnMaskChanged));
+        //public static readonly DependencyProperty ImageProperty =
+        //    DependencyProperty.Register("Image", typeof(ImageSource), typeof(ImageEditor),
+        //        new PropertyMetadata(null, OnImageChanged));
+
+        //public static readonly DependencyProperty MaskProperty =
+        //    DependencyProperty.Register("Mask", typeof(ImageSource), typeof(ImageEditor),
+        //        new PropertyMetadata(null, OnMaskChanged));
 
         public static readonly DependencyProperty AllowPreviewProperty =
             DependencyProperty.Register("AllowPreview", typeof(bool), typeof(ImageEditor),
@@ -43,17 +37,23 @@ namespace CascadePass.Glazier.UI
 
         #region Dependency Properties
 
-        public ImageSource Image
+        public GlazierViewModel GlazierViewModel
         {
-            get => (ImageSource)GetValue(ImageProperty);
-            set => SetValue(ImageProperty, value);
+            get => (GlazierViewModel)GetValue(GlazierViewModelProperty);
+            set => SetValue(GlazierViewModelProperty, value);
         }
 
-        public ImageSource Mask
-        {
-            get => (ImageSource)GetValue(MaskProperty);
-            set => SetValue(MaskProperty, value);
-        }
+        //public ImageSource Image
+        //{
+        //    get => (ImageSource)GetValue(ImageProperty);
+        //    set => SetValue(ImageProperty, value);
+        //}
+
+        //public ImageSource Mask
+        //{
+        //    get => (ImageSource)GetValue(MaskProperty);
+        //    set => SetValue(MaskProperty, value);
+        //}
 
         public bool AllowPreview
         {
@@ -63,19 +63,19 @@ namespace CascadePass.Glazier.UI
 
         #endregion
 
-        private static void OnImageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private void UpdateBinding(BindingExpression binding)
         {
-            if (d is not ImageEditor control)
+            if (binding?.Target is DependencyObject target)
             {
-                return;
-            }
-        }
-
-        private static void OnMaskChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is not ImageEditor control)
-            {
-                return;
+                var dispatcher = Dispatcher;
+                if (dispatcher != null && !dispatcher.CheckAccess())
+                {
+                    dispatcher.Invoke(() => binding.UpdateTarget());
+                }
+                else
+                {
+                    binding.UpdateTarget();
+                }
             }
         }
 
@@ -84,6 +84,24 @@ namespace CascadePass.Glazier.UI
             if (d is not ImageEditor control)
             {
                 return;
+            }
+        }
+
+        private static void OnGlazierViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not ImageEditor control || control.GlazierViewModel is null)
+            {
+                return;
+            }
+
+            control.GlazierViewModel.PropertyChanged += control.GlazierViewModel_PropertyChanged;
+        }
+
+        private void GlazierViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (string.Equals(e.PropertyName, nameof(GlazierViewModel.PreviewImage)))
+            {
+                this.UpdateBinding(BindingOperations.GetBindingExpression(this.PreviewImage, Image.SourceProperty));
             }
         }
     }

--- a/src/Glazier.UI/Infrastructure/Converters/GlazeMethodToBoolConverter.cs
+++ b/src/Glazier.UI/Infrastructure/Converters/GlazeMethodToBoolConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+
+namespace CascadePass.Glazier.UI
+{
+    public class GlazeMethodToBoolConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is GlazeMethod glazeMethod && parameter is GlazeMethod compareMethod)
+            {
+                return glazeMethod == compareMethod;
+            }
+
+            return DependencyProperty.UnsetValue;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is GlazeMethod glazeMethod && parameter is GlazeMethod compareMethod)
+            {
+                return glazeMethod == compareMethod;
+            }
+
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}

--- a/src/Glazier.UI/LivePreviewToolbar.xaml.cs
+++ b/src/Glazier.UI/LivePreviewToolbar.xaml.cs
@@ -1,20 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace CascadePass.Glazier.UI
 {
@@ -24,6 +11,10 @@ namespace CascadePass.Glazier.UI
     public partial class LivePreviewToolbar : UserControl
     {
         #region Dependency Properties
+
+        public static readonly DependencyProperty GlazierViewModelProperty =
+            DependencyProperty.Register("GlazierViewModel", typeof(GlazierViewModel), typeof(LivePreviewToolbar),
+                new PropertyMetadata(null, null));
 
         public static readonly DependencyProperty IsSettingsExpandedProperty =
             DependencyProperty.Register("IsSettingsExpanded", typeof(bool), typeof(LivePreviewToolbar),
@@ -54,15 +45,21 @@ namespace CascadePass.Glazier.UI
         public LivePreviewToolbar()
         {
             this.InitializeComponent();
+
+            this.Loaded += this.ToolbarBorder_Loaded;
         }
 
         #region Properties
 
-        internal GlazierViewModel GlazierViewModel { get; set; }
-
         internal DateTime PopupLastOpened { get; set; }
 
         #region Dependency Properties
+
+        public GlazierViewModel GlazierViewModel
+        {
+            get => (GlazierViewModel)GetValue(GlazierViewModelProperty);
+            set => SetValue(GlazierViewModelProperty, value);
+        }
 
         public bool IsSettingsExpanded
         {
@@ -162,21 +159,6 @@ namespace CascadePass.Glazier.UI
 
         #endregion
 
-        public override void OnApplyTemplate()
-        {
-            base.OnApplyTemplate();
-
-            if (this.Parent is FrameworkElement frameworkElement && frameworkElement.DataContext is GlazierViewModel vm)
-            {
-                this.GlazierViewModel = vm;
-                this.GlazierViewModel.PropertyChanged += this.OnGlazierViewModelPropertyChanged;
-                this.BackgroundRemovalMethod = this.GlazierViewModel.GlazeMethod;
-
-                DependencyPropertyChangedEventArgs args = new(BackgroundRemovalMethodProperty, null, this.BackgroundRemovalMethod);
-                LivePreviewToolbar.OnBackgroundRemovalMethodChanged(this, args);
-            }
-        }
-
         private void OnGlazierViewModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(GlazierViewModel.GlazeMethod))
@@ -203,6 +185,16 @@ namespace CascadePass.Glazier.UI
 
         private void ToolbarBorder_Loaded(object sender, RoutedEventArgs e)
         {
+            if (this.Parent is FrameworkElement frameworkElement && frameworkElement.DataContext is GlazierViewModel vm)
+            {
+                this.GlazierViewModel = vm;
+                this.GlazierViewModel.PropertyChanged += this.OnGlazierViewModelPropertyChanged;
+                this.BackgroundRemovalMethod = this.GlazierViewModel.GlazeMethod;
+
+                DependencyPropertyChangedEventArgs args = new(BackgroundRemovalMethodProperty, null, this.BackgroundRemovalMethod);
+                LivePreviewToolbar.OnBackgroundRemovalMethodChanged(this, args);
+            }
+
             DependencyPropertyDescriptor
                 .FromProperty(Border.OpacityProperty, typeof(Border))
                 .AddValueChanged(ToolbarBorder, OnOpacityChanged)

--- a/src/Glazier.UI/MainWindow.xaml
+++ b/src/Glazier.UI/MainWindow.xaml
@@ -120,7 +120,7 @@
                 <local:ImageEditor
                     x:Name="PreviewImage"
                     Grid.Column="2"
-                    Image="{Binding PreviewImage}" />
+                    GlazierViewModel="{Binding}" />
                 </Grid>
         </Border>
     </DockPanel>

--- a/src/Glazier.UI/MainWindow.xaml.cs
+++ b/src/Glazier.UI/MainWindow.xaml.cs
@@ -60,10 +60,6 @@ namespace CascadePass.Glazier.UI
             {
                 this.UpdateBinding(BindingOperations.GetBindingExpression(this.DisplayImage, Image.SourceProperty));
             }
-            else if (e.PropertyName == nameof(GlazierViewModel.PreviewImage))
-            {
-                this.UpdateBinding(BindingOperations.GetBindingExpression(this.PreviewImage, ImageEditor.ImageProperty));
-            }
             else if (e.PropertyName == nameof(GlazierViewModel.SourceFilename))
             {
                 this.UpdateBinding(BindingOperations.GetBindingExpression(this.InputFile, CommandTextBox.UserTextProperty));
@@ -76,11 +72,6 @@ namespace CascadePass.Glazier.UI
                 this.UpdateBinding(BindingOperations.GetBindingExpression(this.ColorPicker, ColorPicker.SelectedColorProperty));
                 this.UpdateBinding(BindingOperations.GetBindingExpression(this.ColorPicker, ColorPicker.BackgroundProperty));
             }
-            //else if (e.PropertyName == nameof(GlazierViewModel.IsImageLoaded))
-            //{
-            //    this.UpdateBinding(BindingOperations.GetBindingExpression(this.DestinationFile, CommandTextBox.VisibilityProperty));
-            //    this.UpdateBinding(BindingOperations.GetBindingExpression(this.DestinationFileLabel, TextBlock.VisibilityProperty));
-            //}
             else if (e.PropertyName == nameof(GlazierViewModel.IsImageNeeded))
             {
                 this.UpdateBinding(BindingOperations.GetBindingExpression(this.ImagePreviewSection, TextBlock.VisibilityProperty));


### PR DESCRIPTION
The UI initially shows a form allowing the user to set a file name and a glaze mode.  But the application would crash if the user changes the glaze mode before a picture was loaded.  This update corrects the data binding issue causing the crash.