### PR TITLE
Update file path generation

### DIFF
--- a/src/Glazier.UI.Test/SettingsTests.cs
+++ b/src/Glazier.UI.Test/SettingsTests.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualBasic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
@@ -39,14 +38,17 @@ namespace CascadePass.Glazier.UI.Tests
             // Background brush should be set (not blank)
             Assert.IsNotNull(defaultSettings.BackgroundBrushKey);
 
+            // Resizing options should not be empty
             Assert.IsFalse(defaultSettings.ResizingOptions is null || defaultSettings.ResizingOptions.Count == 0, "No resizing options");
         }
 
         [TestMethod]
         public void PropertyChange_Should_UpdateValue()
         {
-            var settings = new Settings();
-            settings.FontSize = 16;
+            var settings = new Settings
+            {
+                FontSize = 16
+            };
 
             Assert.AreEqual(16, settings.FontSize);
         }
@@ -96,7 +98,6 @@ namespace CascadePass.Glazier.UI.Tests
             Settings.LoadFromFile("NonExistentFile.json", jsonOptions);
         }
 
-
         [TestMethod]
         public void BackgroundBrushKey_RejectsInvalidBrushKeys()
         {
@@ -127,6 +128,12 @@ namespace CascadePass.Glazier.UI.Tests
             Assert.IsTrue(Settings.GetDefaultSizes().Any(s => s.Width == 64 && s.Height == 64));
             Assert.IsTrue(Settings.GetDefaultSizes().Any(s => s.Width == 128 && s.Height == 128));
             Assert.IsTrue(Settings.GetDefaultSizes().Any(s => s.Width == 256 && s.Height == 256));
+        }
+
+        [TestMethod]
+        public void GetApplicationName_ReturnsKnownValue()
+        {
+            Assert.AreEqual("GlazierTestHost", Settings.GetApplicationName(), "Application name should be 'GlazierTestHost' in unit tests.");
         }
 
         #region Validation Methods

--- a/src/Glazier.UI/WorkspaceViewModel.cs
+++ b/src/Glazier.UI/WorkspaceViewModel.cs
@@ -87,6 +87,53 @@ namespace CascadePass.Glazier.UI
 
         #region Properties
 
+
+        #region Settings
+
+        public string SettingsFilename { get; set; }
+
+        /// <summary>
+        /// Gets or sets the application settings.
+        /// </summary>
+        /// <remarks>When the settings are updated, the property ensures that event handlers for property
+        /// changes are properly managed. Assigning a new value will detach event handlers from the old settings
+        /// instance (if any) and attach them to the new instance.</remarks>
+        /// <exception cref="ArgumentNullException">Thrown when the value is set to null.</exception>"
+        public Settings Settings
+        {
+            get => this.settings;
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value), "Settings cannot be null.");
+                }
+
+                var old = this.settings;
+                bool changed = this.SetPropertyValue(ref this.settings, value, nameof(this.Settings));
+
+                if (changed)
+                {
+                    if (old is not null)
+                    {
+                        old.PropertyChanged -= this.Settings_PropertyChanged;
+                    }
+
+                    this.Settings.PropertyChanged += this.Settings_PropertyChanged;
+                }
+            }
+        }
+
+        #endregion
+
+        #region GlazierViewModel
+
+        /// <summary>
+        /// Gets or sets the view model for the glazier component.
+        /// </summary>
+        /// <remarks>When the property value changes, event handlers are updated to reflect the new
+        /// instance.  Ensure that the new value is properly initialized before setting this property to avoid
+        /// unexpected behavior.</remarks>
         public GlazierViewModel GlazierViewModel
         {
             get => this.glazierViewModel;
@@ -109,30 +156,9 @@ namespace CascadePass.Glazier.UI
             }
         }
 
-        public Settings Settings
-        {
-            get => this.settings;
-            set
-            {
-                if (value == null)
-                {
-                    throw new System.ArgumentNullException(nameof(value), "Settings cannot be null.");
-                }
+        #endregion
 
-                var old = this.settings;
-                bool changed = this.SetPropertyValue(ref this.settings, value, nameof(this.Settings));
-
-                if (changed)
-                {
-                    if (old is not null)
-                    {
-                        old.PropertyChanged -= this.Settings_PropertyChanged;
-                    }
-
-                    this.Settings.PropertyChanged += this.Settings_PropertyChanged;
-                }
-            }
-        }
+        #region SettingsViewModel
 
         public SettingsViewModel SettingsViewModel
         {
@@ -158,13 +184,13 @@ namespace CascadePass.Glazier.UI
             }
         }
 
+        #endregion
+
         public ObservableCollection<GlazeMethodViewModel> AvailableGlazeMethods
         {
             get => this.availableGlazeMethods;
             set => this.SetPropertyValue(ref this.availableGlazeMethods, value, nameof(this.AvailableGlazeMethods));
         }
-
-        public string SettingsFilename { get; set; }
 
         public bool IsSettingsPageVisible
         {


### PR DESCRIPTION
Generate a different path for the settings file in application vs unit test mode.  Because the settings auto saves changes by default, unit tests were changing settings for dev users.