### PR TITLE
Make Settings Available Immediately

### DIFF
--- a/src/Glazier.UI/CommandTextBox.xaml
+++ b/src/Glazier.UI/CommandTextBox.xaml
@@ -7,17 +7,23 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
-    <Border Style="{DynamicResource CommandTextBoxBorder}">
+    <Border Style="{DynamicResource CommandTextBoxBorder}" AutomationProperties.Name="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=InsetText, Mode=OneWay}">
         <DockPanel LastChildFill="True">
             <Button
                 x:Name="SearchButton"
                 DockPanel.Dock="Right"
                 Command="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Command, Mode=OneWay}"
+                ToolTip="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=InsetText, Mode=OneWay}"
+                AutomationProperties.Name="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=InsetText, Mode=OneWay}"
+                Visibility="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=IsSingleButton, Mode=OneWay, Converter={StaticResource boolToVisibility}}"
                 BorderBrush="Transparent"
                 Background="Transparent"
                 >
                 <Image Source="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=CommandIcon, Mode=OneWay}" Style="{DynamicResource Icon}" />
             </Button>
+
+            <ContentPresenter x:Name="ButtonsPresenter" DockPanel.Dock="Right" />
+
 
             <Grid>
                 <TextBlock x:Name="InsetLabel" Style="{DynamicResource CommandTextBoxInsetLabelStyle}">                    

--- a/src/Glazier.UI/LoadImageForm.xaml
+++ b/src/Glazier.UI/LoadImageForm.xaml
@@ -15,12 +15,31 @@
                 Margin="0,4,0,0"
                 InsetText="{x:Static local:Resources.Label_SourceFile}"
                 InsetIcon="/Images/Icons/FolderOpenBlue.png"
-                CommandIcon="/Images/Icons/FolderOpened.png"
-                Command="{Binding BrowseForImageFileCommand}"
                 Opacity=".7"
                 UserText="{Binding SourceFilename}"
-                Visibility="{Binding IsImageNeeded, Converter={StaticResource boolToVisibility}}"
-                />
+                Visibility="{Binding IsImageNeeded, Converter={StaticResource boolToVisibility}}">
+                <local:CommandTextBox.Buttons>
+                    <Button
+                        Command="{Binding EditSettingsCommand, Mode=OneWay}"
+                        ToolTip="{x:Static local:Resources.Settings}"
+                        AutomationProperties.Name="{x:Static local:Resources.Settings}"
+                        BorderBrush="Transparent"
+                        Background="Transparent"
+                        >
+                        <Image Source="/Images/Icons/Settings.png" Style="{DynamicResource Icon}" />
+                    </Button>
+
+                    <Button
+                        Command="{Binding BrowseForImageFileCommand, Mode=OneWay}"
+                        ToolTip="{x:Static local:Resources.Label_SourceFile}"
+                        AutomationProperties.Name="{x:Static local:Resources.Label_SourceFile}"
+                        BorderBrush="Transparent"
+                        Background="Transparent"
+                        >
+                        <Image Source="/Images/Icons/FolderOpened.png"  Style="{DynamicResource Icon}" />
+                    </Button>
+                </local:CommandTextBox.Buttons>
+            </local:CommandTextBox>
 
 
             <Border Background="{DynamicResource AlgorithmSelectorButtonBackgroundBrush}" Margin="0,40,0,4" CornerRadius="12">

--- a/src/Glazier.UI/WorkspaceViewModel.cs
+++ b/src/Glazier.UI/WorkspaceViewModel.cs
@@ -35,7 +35,7 @@ namespace CascadePass.Glazier.UI
         private IThemeListener themeListener;
         private IFileDialogProvider dialogProvider;
 
-        private DelegateCommand browseForImageFile, saveImageData, viewLargePreviewCommand, viewMaskCommand;
+        private DelegateCommand browseForImageFile, saveImageData, viewLargePreviewCommand, viewMaskCommand, editSettingsCommand;
 
         #endregion
 
@@ -299,6 +299,8 @@ namespace CascadePass.Glazier.UI
 
         public ICommand ViewMaskCommand => this.viewMaskCommand ??= new(this.ViewMaskImplementation);
 
+        public ICommand EditSettingsCommand => this.editSettingsCommand ??= new(this.EditSettingsImplementation);
+
         #endregion
 
 
@@ -509,6 +511,12 @@ namespace CascadePass.Glazier.UI
             };
 
             previewWindow.ShowDialog();
+        }
+
+        internal void EditSettingsImplementation()
+        {
+            this.IsSettingsPageVisible = true;
+            this.SettingsViewModel.IsSettingsPageOpen = true;
         }
 
         #endregion


### PR DESCRIPTION
Improve CommandTextBox to allow multiple buttons instead of only one, and use this ability to make settings available before an image is loaded.

![image](https://github.com/user-attachments/assets/b95a841c-b0d8-4251-b76b-7375db88301b)